### PR TITLE
Toa 17/refactor/task split

### DIFF
--- a/app/src/main/java/com/adammcneilly/toa/tasklist/domain/usecases/GetTasksForDateUseCase.kt
+++ b/app/src/main/java/com/adammcneilly/toa/tasklist/domain/usecases/GetTasksForDateUseCase.kt
@@ -10,10 +10,10 @@ import java.time.LocalDate
 interface GetTasksForDateUseCase {
     /**
      * Fetch tasks for the given [date], where the completed property of the task matches the supplied
-     * [completed] argument.
+     * [appendCompletedTasks] argument.
      */
     operator fun invoke(
         date: LocalDate,
-        completed: Boolean,
+        appendCompletedTasks: Boolean,
     ): Flow<TaskListResult>
 }

--- a/app/src/main/java/com/adammcneilly/toa/tasklist/domain/usecases/ProdGetTasksForDateUseCase.kt
+++ b/app/src/main/java/com/adammcneilly/toa/tasklist/domain/usecases/ProdGetTasksForDateUseCase.kt
@@ -1,8 +1,11 @@
 package com.adammcneilly.toa.tasklist.domain.usecases
 
+import com.adammcneilly.toa.core.data.Result
+import com.adammcneilly.toa.tasklist.domain.model.Task
 import com.adammcneilly.toa.tasklist.domain.repository.TaskListResult
 import com.adammcneilly.toa.tasklist.domain.repository.TaskRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combineTransform
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -12,8 +15,27 @@ class ProdGetTasksForDateUseCase @Inject constructor(
 
     override fun invoke(
         date: LocalDate,
-        completed: Boolean,
+        appendCompletedTasks: Boolean,
     ): Flow<TaskListResult> {
-        return taskRepository.fetchTasksForDate(date, completed)
+        val incompleteTasksFlow = taskRepository.fetchTasksForDate(date, false)
+        return if (appendCompletedTasks) getMergedTaskFlow(date, incompleteTasksFlow)
+        else incompleteTasksFlow
+    }
+
+    private fun getMergedTaskFlow(
+        date: LocalDate,
+        incompleteTasksFlow: Flow<Result<List<Task>>>
+    ): Flow<Result<List<Task>>> {
+        val completedTasksFlow = taskRepository.fetchTasksForDate(date, true)
+        return incompleteTasksFlow
+            .combineTransform(completedTasksFlow) { incomplete, complete ->
+                if (incomplete is Result.Success && complete is Result.Success) {
+                    val result = Result.Success(incomplete.data + complete.data)
+                    emit(result)
+                } else {
+                    emit(incomplete)
+                    emit(complete)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/adammcneilly/toa/tasklist/ui/TaskListViewModel.kt
+++ b/app/src/main/java/com/adammcneilly/toa/tasklist/ui/TaskListViewModel.kt
@@ -37,7 +37,7 @@ class TaskListViewModel @Inject constructor(
 
                 getTasksForDateUseCase.invoke(
                     date = selectedDate,
-                    appendCompletedTasks = false,
+                    appendCompletedTasks = true,
                 )
             }
             .onEach { result ->


### PR DESCRIPTION
The PR showcases how you can combine two streams from the DB (complete and incomplete tasks) and append or not the complete list to the incomplete based on a `boolean` argument passed in the `ProdGetTasksForDateUseCase`(what Zhuinden was mentioning during the stream, on which he is correct).

So the `TaskListViewModel` now observes just the `ProdGetTasksForDateUseCase` and it splits the list on its own to completed and incomplete tasks.