### PR TITLE
Allowing gradle build action to cache on all branches.

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -16,10 +16,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          # Only write to the cache for builds on the 'development' branch
-          cache-read-only: ${{ github.ref != 'refs/heads/development' }}
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build Project
         run: ./gradlew assemble

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -20,10 +20,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          # Only write to the cache for builds on the 'development' branch
-          cache-read-only: ${{ github.ref != 'refs/heads/development' }}
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run Tests
         env:

--- a/.github/workflows/danger_checks.yml
+++ b/.github/workflows/danger_checks.yml
@@ -16,10 +16,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          # Only write to the cache for builds on the 'development' branch
-          cache-read-only: ${{ github.ref != 'refs/heads/development' }}
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Set Up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This will make PR builds faster!

Also fixes #193. 